### PR TITLE
Add tune "run" in order to run Herwig event generation on existing ru…

### DIFF
--- a/gen/herwig/gen.sh
+++ b/gen/herwig/gen.sh
@@ -3,21 +3,27 @@ gen_herwig(){
     run)
         PACKAGES="Herwig::v7.2.0-4"
 
-        cmd=$(printf "python3 %s/generate_hwgin.py --herwigfile herwig.in" $(dir_gen))
-        if [ "x${HEPMCFILENAME}" != "x" ]; then cmd=$(printf "%s --hepmcfile %s" "$cmd" ${HEPMCFILENAME}); fi
-        if [ "x${TUNE}" != "x" ]; then cmd=$(printf "%s --tune %s" "$cmd" ${TUNE}); fi
-        if [ "x${ENERGY}" != "x" ]; then cmd=$(printf "%s --energy %s" "$cmd" ${ENERGY}); fi
-        if [ "x${NEV}" != "x" ]; then cmd=$(printf "%s --numevents %s" "$cmd" ${NEV}); fi
-        if [ "x${KTMIN}" != "x" ]; then cmd=$(printf "%s --ktmin %s" "$cmd" ${KTMIN}); fi
-        if [ "x${KTMAX}" != "x" ]; then cmd=$(printf "%s --ktmax %s" "$cmd" ${KTMAX}); fi
-        eval $cmd
-        if [ "x${TUNE}" != "xmb" ]; then
-            cp_input DefaultTune.in .
-            cp_input SoftTune.in .
+        # Define tune "run" in order to run on an existing herwig.run file
+        # This is in particular of relevance for processes where the build
+        # takes a huge amount of time (i.e. NLO processes) where the herwig.run
+        # can be produced for all child jobs in a much more efficient way
+        # using local clusters
+        if [ "x${TUNE}" != "xrun" ]; then
+            cmd=$(printf "python3 %s/generate_hwgin.py --herwigfile herwig.in" $(dir_gen))
+            if [ "x${HEPMCFILENAME}" != "x" ]; then cmd=$(printf "%s --hepmcfile %s" "$cmd" ${HEPMCFILENAME}); fi
+            if [ "x${TUNE}" != "x" ]; then cmd=$(printf "%s --tune %s" "$cmd" ${TUNE}); fi
+            if [ "x${ENERGY}" != "x" ]; then cmd=$(printf "%s --energy %s" "$cmd" ${ENERGY}); fi
+            if [ "x${NEV}" != "x" ]; then cmd=$(printf "%s --numevents %s" "$cmd" ${NEV}); fi
+            if [ "x${KTMIN}" != "x" ]; then cmd=$(printf "%s --ktmin %s" "$cmd" ${KTMIN}); fi
+            if [ "x${KTMAX}" != "x" ]; then cmd=$(printf "%s --ktmax %s" "$cmd" ${KTMAX}); fi
+            eval $cmd
+            if [ "x${TUNE}" != "xmb" ]; then
+                cp_input DefaultTune.in .
+                cp_input SoftTune.in .
+            fi
+            run_in_env 'Herwig --repo=${HERWIG_ROOT}/share/Herwig/HerwigDefaults.rpo read herwig.in' > setup.log
         fi
 
-
-        run_in_env 'Herwig --repo=${HERWIG_ROOT}/share/Herwig/HerwigDefaults.rpo read herwig.in' > setup.log
         run_in_env 'Herwig --repo=${HERWIG_ROOT}/share/Herwig/HerwigDefaults.rpo run herwig.run -N ${NEV} --seed ${SEED}' > hwgen.log
         ;;
     *)


### PR DESCRIPTION
…n files

The build phase for NLO processes can take a huge
amount of time. Doing this for each job as a separate
job is extremely inefficient and will lead to the job being
killed due to exceeding of the time limit. Instead this
step can be nicely parallelized on local clusters, making
this step much more efficient, so that for the processing
on the grid only the herwig.run file is needed. Therefore
the tune "run" skips herwig configuration and expects
a herwig.run file to be present in the current folder.

In addition add NLO dijet tunes using OpenLoops
or MadGraph as external loop providers.