### PR TITLE
Setting long-lived particles to stable + option for HF pt-hard production in Herwig

### DIFF
--- a/gen/herwig/generate_hwgin.py
+++ b/gen/herwig/generate_hwgin.py
@@ -45,12 +45,20 @@ def GenerateHerwigInput(outputfile, tune, cmsenegy, events, hepmcfile, ktmin, kt
             isLeadingOrder = False
             kthardmin = 0.
             kthardmax = 0.
-            if tune == "beauty" or tune == "charm":
+            if "beauty" in tune or "charm" in tune:
                 quarktye = 4 if tune == "charm" else 5
                 myfile.write("set /Herwig/MatrixElements/MEHeavyQuark:QuarkType {}\n".format(quarktye))
                 myfile.write("insert /Herwig/MatrixElements/SubProcess:MatrixElements[0] /Herwig/MatrixElements/MEHeavyQuark\n")
-                kthardmin = 0.
-                kthardmax = float(cmsenegy)
+                if "kthard" in tune:
+                    kthardmin = ktmin
+                    kthardmax = ktmax
+                    if kthardmin < 0:
+                        kthardmin = 0
+                    if kthardmax < 0 or kthardmax > cmsenegy:
+                        kthardmax = cmsenegy
+                else:
+                    kthardmin = 0.
+                    kthardmax = float(cmsenegy)
                 isLeadingOrder = True
             elif tune == "dijet_lo":
                 myfile.write("insert /Herwig/MatrixElements/SubProcess:MatrixElements[0] /Herwig/MatrixElements/MEQCD2to2\n")

--- a/gen/herwig/generate_hwgin.py
+++ b/gen/herwig/generate_hwgin.py
@@ -92,7 +92,24 @@ def GenerateHerwigInput(outputfile, tune, cmsenegy, events, hepmcfile, ktmin, kt
             myfile.write("set /Herwig/Cuts/Cuts:MHatMin 0.0*GeV\n")
             myfile.write("set /Herwig/UnderlyingEvent/MPIHandler:IdenticalToUE -1\n")
 
-        # Stable particles with a lifetime > 10 mm (decay externally)
+        # Setting particles stable by hand (based on the definition in AliPythia8):
+        # Those particles are not decayed by Herwig but must be decayed by an external
+        # decayer (i.e. pythia or EVGEN). This is important i.e. for full simulations
+        # where the particles can still interact with the material
+        # - K0l (130)
+        # - K0s (310)
+        # - Lambda (3122)
+        # - Sigma (+ -> 3222, 0 -> 3212, - -> 3112)
+        # - Xi (0 -> 3322, - -> 3312)
+        # - Omega (3334)
+        # Also set corresponding antiparticles to stable
+        stableparticles = ["K0", "Kbar0", "Lambda0", "Lambdabar0", "Sigma0", "Sigmabar0", 
+                           "Sigma+", "Sigmabar-", "Sigma-", "Sigmabar+", "Xi0", "Xibar0" 
+                           "Xi-", "Xibar+", "Omega-", "Omegabar+"]
+        for particle in stableparticles:
+            myfile.write("set /Herwig/Particle/{}:Stable Stable".format(particle))
+
+        # In addition: stable particles with a lifetime > 10 mm (decay externally)
         myfile.write("set /Herwig/Decays/DecayHandler:MaxLifeTime 10*mm\n")
         myfile.write("set /Herwig/Decays/DecayHandler:LifeTimeOption Average\n")
 


### PR DESCRIPTION
- Setting long lived particles + corresponding antiparticles based on definition in AliPythia8 to stable
- Add option to run HF (pp->c+X, pp->b->X) in pt-hard bins