### PR TITLE
Adjust handling of packages for official and user builds

### DIFF
--- a/lib/tools.sh
+++ b/lib/tools.sh
@@ -8,10 +8,25 @@ cp_input() {
 
 run_in_env() {
     if [[ -n ${GEN_PACKAGES} ]]; then
-#	/cvmfs/alice.cern.ch/bin/alienv setenv ${GEN_PACKAGES} -c "$*"
-	(eval $(alienv --no-refresh printenv ${GEN_PACKAGES}) && eval $*)
-#	alienv setenv ${GEN_PACKAGES} -c "$*"
+#	    /cvmfs/alice.cern.ch/bin/alienv setenv ${GEN_PACKAGES} -c "$*"
+        # Distinction needed for local builds cvmfs builds:
+        # ---------------------------------------------------------------
+        # In case of local builds aligenmc should not refresh the modules 
+        # as this can lead to conflicts when two processes are refreshing
+        # modules at the same time (local batch jobs). In case of cvmfs
+        # packages alienv from cvmfs is not aware of the option --no-refresh,
+        # consequently it must not be called. In order to distinguish between
+        # local and cvmfs pacakges one can make use of the "::" in the name
+        # of cmvfs packages
+        if [ "x$(echo ${GEN_PACKAGES} | grep :: )" != "x" ]; then
+            # cvmfs package
+	        (eval $(alienv  printenv ${GEN_PACKAGES}) && eval $*)
+        else
+            # package from local build
+	        (eval $(alienv --no-refresh printenv ${GEN_PACKAGES}) && eval $*)
+        fi
+#	    alienv setenv ${GEN_PACKAGES} -c "$*"
     else
-	/bin/bash -c "$*"
+	    /bin/bash -c "$*"
     fi
 }


### PR DESCRIPTION
The behaviour of alienv with respect to modulefiles
is different for official and user builds. In case of user
builds by default alienv updates the module directory,
which is unwanted in particular when running multiple
jobs with aligenmc in parallel on a batch cluster.
Therefore in this case the option "--no-refresh" should
be specified.

In case of official packages from cvmfs a different
alienv is used, which does not support the option
"--no-refresh", leading to a failure of the execution.
Therefore the option must not be specified in case
of official pacakges.

The two modes can be distinguished by the package
name: Official packages split package and version
via "::", local builds via "/". It is expected that local
and cvmfs packages are not mixed.