### PR TITLE
Reduce verbosity in log files

### DIFF
--- a/gen/herwig/generate_hwgin.py
+++ b/gen/herwig/generate_hwgin.py
@@ -34,6 +34,9 @@ def GenerateHerwigInput(outputfile, tune, cmsenegy, events, hepmcfile, ktmin, kt
     with open(outputfile, "w") as myfile:
         myfile.write("read snippets/PPCollider.in\n") # Markus: Take PPCollider.in from Herwig repositiory instead of custom version
         myfile.write("set /Herwig/Generators/EventGenerator:EventHandler:LuminosityFunction:Energy {}.0\n".format(cmsenegy))
+        # reduce verbosity in log file,
+        # print only the first event (for whatever reason Herwig uses N+1 here)
+        myfile.write("set /Herwig/Generators/EventGenerator:PrintEvent 2\n") 
         if tune == "mb":
             # MB tune from Herwig repo
             myfile.write("set /Herwig/Shower/ShowerHandler:IntrinsicPtGaussian 2.2*GeV\n")


### PR DESCRIPTION
By default Herwig prints the first 10 events in the log file.
Those create unnecessary large log files, which however
contain useful information and should be kept for the
productions. For debugging purpose we keep the
printout of the first event.